### PR TITLE
Add tool authorization feature

### DIFF
--- a/demo/http/Gemfile.lock
+++ b/demo/http/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    active_mcp (0.1.0)
+    active_mcp (0.1.1)
       json-schema
       rails (>= 6.0.0, < 8.0.0)
 

--- a/demo/http/app/tools/secure_notes_tool.rb
+++ b/demo/http/app/tools/secure_notes_tool.rb
@@ -8,6 +8,12 @@ class SecureNotesTool < ActiveMcp::Tool
   property :title, :string, required: false, description: "ノートタイトル（createで必要）"
   property :content, :string, required: false, description: "ノート内容（createで必要）"
 
+  def self.authorized?(auth_info)
+    return false unless auth_info
+    return false unless auth_info[:type] == :bearer
+    auth_info[:token] == "valid-token" || auth_info[:token] == "admin-token"
+  end
+
   def call(action:, note_id: nil, title: nil, content: nil, auth_info: nil, **args)
     unless auth_info.present?
       raise "この機能は認証されたユーザーのみ利用できます"

--- a/lib/active_mcp/tool.rb
+++ b/lib/active_mcp/tool.rb
@@ -34,6 +34,10 @@ module ActiveMcp
       def inherited(subclass)
         registered_tools << subclass
       end
+
+      def authorized?(auth_info)
+        true
+      end
     end
 
     def initialize

--- a/lib/generators/active_mcp/tool/templates/tool.rb.erb
+++ b/lib/generators/active_mcp/tool/templates/tool.rb.erb
@@ -5,6 +5,23 @@ class <%= class_name %> < ActiveMcp::Tool
   property :param2, :string, required: false, description: "Second parameter description"
   # Add more parameters as needed
   
+  # Uncomment and modify this method to implement authorization control
+  # This controls who can see and use this tool
+  # def self.authorized?(auth_info)
+  #   # Example: require authentication
+  #   # return false unless auth_info
+  #   
+  #   # Example: require a specific authentication type
+  #   # return false unless auth_info[:type] == :bearer
+  #   
+  #   # Example: check for admin permissions
+  #   # admin_tokens = ["admin-token"]
+  #   # return admin_tokens.include?(auth_info[:token])
+  #   
+  #   # Default: allow all access
+  #   true
+  # end
+  
   def call(param1:, param2: nil, auth_info: nil, **args)
     # Authentication information can be accessed via _auth_info parameter
     # auth_info = { type: :bearer, token: "xxx", header: "Bearer xxx" }

--- a/test/controllers/active_mcp/authorization_test.rb
+++ b/test/controllers/active_mcp/authorization_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+
+module ActiveMcp
+  class AuthorizationTest < ActionController::TestCase
+    setup do
+      @routes = ActiveMcp::Engine.routes
+      @controller = ActiveMcp::BaseController.new
+
+      # 既存のツールをクリア
+      ActiveMcp::Tool.registered_tools = []
+
+      # テスト用のツールを登録
+      require_relative "../../dummy/app/models/public_tool"
+      require_relative "../../dummy/app/models/auth_protected_tool"
+      require_relative "../../dummy/app/models/admin_only_tool"
+
+      # 明示的に登録
+      ActiveMcp::Tool.registered_tools << PublicTool
+      ActiveMcp::Tool.registered_tools << AuthProtectedTool
+      ActiveMcp::Tool.registered_tools << AdminOnlyTool
+    end
+
+    test "should include all tools in tools list without authentication" do
+      # 認証なしでツールリストを取得
+      post :index, params: { method: "tools/list" }
+      assert_response :success
+
+      json = JSON.parse(response.body)
+      tools = json["result"]
+
+      # 公開ツールはリストに含まれる
+      assert_not_nil tools.find { |t| t["name"] == "public" }
+
+      # 認証が必要なツールはリストに含まれない
+      assert_nil tools.find { |t| t["name"] == "auth_protected" }
+      assert_nil tools.find { |t| t["name"] == "admin_only" }
+    end
+
+    test "should include authorized tools in tools list with valid token" do
+      # 有効なトークンで認証
+      @request.headers["Authorization"] = "Bearer valid-token"
+      post :index, params: { method: "tools/list" }
+      assert_response :success
+
+      json = JSON.parse(response.body)
+      tools = json["result"]
+
+      # 公開ツールと認証が必要なツールはリストに含まれる
+      assert_not_nil tools.find { |t| t["name"] == "public" }
+      assert_not_nil tools.find { |t| t["name"] == "auth_protected" }
+
+      # 管理者専用ツールはリストに含まれない
+      assert_nil tools.find { |t| t["name"] == "admin_only" }
+    end
+
+    test "should include all tools in tools list with admin token" do
+      # 管理者トークンで認証
+      @request.headers["Authorization"] = "Bearer admin-token"
+      post :index, params: { method: "tools/list" }
+      assert_response :success
+
+      json = JSON.parse(response.body)
+      tools = json["result"]
+
+      # 全てのツールがリストに含まれる
+      assert_not_nil tools.find { |t| t["name"] == "public" }
+      assert_not_nil tools.find { |t| t["name"] == "auth_protected" }
+      assert_not_nil tools.find { |t| t["name"] == "admin_only" }
+    end
+
+    test "should allow access to public tool without authentication" do
+      arguments = { query: "test" }.to_json
+      post :index, params: {
+        method: "tools/call",
+        name: "public",
+        arguments: arguments
+      }
+
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert_equal "Public search result for: test", json["result"]
+    end
+
+    test "should deny access to protected tool without authentication" do
+      arguments = { resource_id: "1", action: "read" }.to_json
+      post :index, params: {
+        method: "tools/call",
+        name: "auth_protected",
+        arguments: arguments
+      }
+
+      assert_response :forbidden
+      json = JSON.parse(response.body)
+      assert_not_nil json["error"]
+      assert_equal "Unauthorized: Access to tool 'auth_protected' denied", json["error"]
+    end
+
+    test "should allow access to protected tool with valid token" do
+      @request.headers["Authorization"] = "Bearer valid-token"
+      arguments = { resource_id: "1", action: "read" }.to_json
+      post :index, params: {
+        method: "tools/call",
+        name: "auth_protected",
+        arguments: arguments
+      }
+
+      assert_response :success
+    end
+
+    test "should deny access to admin tool with regular token" do
+      @request.headers["Authorization"] = "Bearer valid-token"
+      arguments = { command: "test" }.to_json
+      post :index, params: {
+        method: "tools/call",
+        name: "admin_only",
+        arguments: arguments
+      }
+
+      assert_response :forbidden
+      json = JSON.parse(response.body)
+      assert_not_nil json["error"]
+      assert_equal "Unauthorized: Access to tool 'admin_only' denied", json["error"]
+    end
+
+    test "should allow access to admin tool with admin token" do
+      @request.headers["Authorization"] = "Bearer admin-token"
+      arguments = { command: "test" }.to_json
+      post :index, params: {
+        method: "tools/call",
+        name: "admin_only",
+        arguments: arguments
+      }
+
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert_equal "Admin command executed: test", json["result"]
+    end
+  end
+end

--- a/test/dummy/app/models/admin_only_tool.rb
+++ b/test/dummy/app/models/admin_only_tool.rb
@@ -1,0 +1,15 @@
+class AdminOnlyTool < ActiveMcp::Tool
+  description "This tool is only accessible by admins"
+
+  property :command, :string, required: true, description: "Admin command to execute"
+
+  def self.authorized?(auth_info)
+    return false unless auth_info
+    return false unless auth_info[:type] == :bearer
+    auth_info[:token] == "admin-token"
+  end
+
+  def call(command:, auth_info: nil)
+    "Admin command executed: #{command}"
+  end
+end

--- a/test/dummy/app/models/auth_protected_tool.rb
+++ b/test/dummy/app/models/auth_protected_tool.rb
@@ -4,6 +4,12 @@ class AuthProtectedTool < ActiveMcp::Tool
   property :resource_id, :string, required: true, description: "ID of the protected resource"
   property :action, :string, required: false, description: "Action to perform on the resource"
 
+  def self.authorized?(auth_info)
+    return false unless auth_info
+    return false unless auth_info[:type] == :bearer
+    auth_info[:token] == "valid-token" || auth_info[:token] == "admin-token"
+  end
+
   def call(resource_id:, action: "read", auth_info: nil, **args)
     unless auth_info.present?
       raise "Authentication is required to access protected resources"
@@ -35,6 +41,8 @@ class AuthProtectedTool < ActiveMcp::Tool
   def authenticate_user(auth_type, token)
     if auth_type == :bearer && token == "valid-token"
       {id: 1, name: "Admin User"}
+    elsif auth_type == :bearer && token == "admin-token"
+      {id: 1, name: "Super Admin"}
     elsif auth_type == :basic && token == "dXNlcjpwYXNz" # user:pass in base64
       {id: 2, name: "Regular User"}
     else

--- a/test/dummy/app/models/public_tool.rb
+++ b/test/dummy/app/models/public_tool.rb
@@ -1,0 +1,9 @@
+class PublicTool < ActiveMcp::Tool
+  description "A public tool that can be accessed without authentication"
+
+  property :query, :string, required: true, description: "Search query"
+
+  def call(query:, auth_info: nil)
+    "Public search result for: #{query}"
+  end
+end


### PR DESCRIPTION
## Summary
- Add authorization capabilities to MCP tools
- Implement \ method for tool access control
- Filter available tools list based on authentication context
- Add tests for authorization functionality
- Update documentation with authorization examples

## Test plan
1. Run the test suite to verify authorization functionality works as expected
2. Test with different authorization tokens to verify proper access control
3. Verify unauthorized tools are not listed in tools/list response
4. Verify unauthorized access attempts return 403 error

🤖 Generated with [Claude Code](https://claude.ai/code)